### PR TITLE
app_identifier 에러 수정

### DIFF
--- a/.github/workflows/build-mobile-deploy.yml
+++ b/.github/workflows/build-mobile-deploy.yml
@@ -57,7 +57,7 @@ jobs:
 
         run: |
           cd ios
-          bundle exec fastlane match development --readonly # 개발용 프로파일 다운로드
+          bundle exec fastlane match development --readonly --app_identifier com.fourchoi.deploySample # 개발용 프로파일 다운로드
 
       # 6. Build iOS app
       - name: Build iOS IPA

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,7 +1,10 @@
 platform :ios do
   desc "Build and sign the iOS app"
   lane :build_and_sign do
-    match(type: "development") # 개발용 서명
+    match(
+      type: "development",
+      app_identifier: ["com.fourchoi.deploySample"]
+    ) # 개발용 서명
     build_app(workspace: "Runner.xcworkspace", scheme: "Runner") # 앱빌드
   end
 end


### PR DESCRIPTION
- Matchfile에 app_identifier를 넣는것으로 완전하지 않음
- Fastfile에 match시 app_identifier를 명시
- 병행해서 yml에 fastlane cmd에 동시에 app_identifier를 명시
- 위의 둘중에 하나만 진행해도 된다고 함